### PR TITLE
feat: Implementa análise de documentos com DeepSeek

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "input-otp": "^1.4.2",
         "jspdf": "^3.0.1",
         "lucide-react": "^0.453.0",
+        "mammoth": "^1.7.0",
         "memoizee": "^0.4.17",
         "memorystore": "^1.6.7",
         "multer": "^2.0.0",
@@ -67,6 +68,7 @@
         "openid-client": "^6.5.0",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
+        "pdf-parse": "^1.1.1",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -3698,6 +3700,14 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3789,6 +3799,14 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/aria-hidden": {
       "version": "1.2.4",
@@ -3891,6 +3909,25 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3902,6 +3939,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -4608,6 +4650,11 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -5212,6 +5259,14 @@
       "peerDependencies": {
         "drizzle-orm": ">=0.36.0",
         "zod": ">=3.0.0"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -6144,6 +6199,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -6351,6 +6411,25 @@
         "core-js": "^3.6.0",
         "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6637,6 +6716,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6671,6 +6760,29 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.9.0.tgz",
+      "integrity": "sha512-F+0NxzankQV9XSUAuVKvkdQK0GbtGGuqVnND9aVf9VSeUA82LQa29GjLqYU6Eez8LHqSJG3eGiDW3224OKdpZg==",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6975,6 +7087,11 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -7157,11 +7274,21 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -7207,6 +7334,14 @@
       "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -7256,6 +7391,26 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -8275,6 +8430,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -8370,6 +8530,11 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
@@ -9231,6 +9396,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -10062,6 +10232,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,9 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "pdf-parse": "^1.1.1",
+    "mammoth": "^1.7.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.0",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,6 +22,8 @@ import * as fs from "fs";
 import * as path from "path";
 import { formatDistanceToNow } from "date-fns";
 import { ptBR } from "date-fns/locale";
+import pdf from "pdf-parse";
+import mammoth from "mammoth";
 
 // Setup multer for file uploads
 const upload = multer({
@@ -302,18 +304,31 @@ export async function registerRoutes(app: Express): Promise<Server> {
         });
       }
       
-      // Extract text from document (simplified - in production would use pdf-parse/mammoth)
-      // For this implementation, we'll pretend we've extracted text
-      const extractedText = `This is a sample legal document containing contract terms. 
-      SECTION 1: INTRODUCTION
-      This agreement is made between the parties on this date.
-      
-      SECTION 2: TERMS
-      2.1 The parties agree to the following terms...
-      2.2 Payment shall be made within 30 days...
-      
-      SECTION 3: TERMINATION
-      This agreement may be terminated by either party with written notice.`;
+      let extractedText: string;
+      try {
+        if (req.file.mimetype === 'application/pdf') {
+          const dataBuffer = fs.readFileSync(req.file.path);
+          const data = await pdf(dataBuffer);
+          extractedText = data.text;
+        } else if (
+          req.file.mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+          req.file.mimetype === 'application/msword'
+        ) {
+          const result = await mammoth.extractRawText({ path: req.file.path });
+          extractedText = result.value;
+        } else {
+          // Clean up the uploaded file if it's not supported
+          fs.unlinkSync(req.file.path);
+          return res.status(400).json({ message: 'Unsupported file type for text extraction.' });
+        }
+        console.log("Texto extraído (primeiros 500 caracteres):", extractedText.substring(0, 500));
+      } catch (extractionError) {
+        console.error("Falha na extração de texto:", extractionError);
+        console.error("Error extracting text from document:", extractionError);
+        // Clean up the uploaded file in case of extraction error
+        fs.unlinkSync(req.file.path);
+        return res.status(500).json({ message: "Failed to extract text from document" });
+      }
       
       // Determine document type (simplified)
       let documentType: "contract" | "petition" | "power_of_attorney" | "general" = "general";
@@ -326,8 +341,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       
       // Analyze document with OpenAI
-      const analysis = await analyzeDocument(extractedText, documentType);
-      
+      const analysis = await aiService.analyzeDocument(extractedText, documentType as "contract" | "petition" | "power_of_attorney" | "general");
+      console.log("Análise recebida do aiService:", JSON.stringify(analysis, null, 2));
       // Save document to database
       const documentId = uuidv4();
       const fileInfo = `${req.file.size > 1024 * 1024 ? 


### PR DESCRIPTION
Este commit introduz a funcionalidade de análise de documentos PDF e DOCX utilizando a IA DeepSeek.

Principais alterações:
- Adiciona dependências `pdf-parse` para extração de texto de PDFs e `mammoth` para extração de texto de DOCX.
- Modifica a rota `/api/documents/analyze` (server/routes.ts) para:
  - Extrair o conteúdo textual dos arquivos enviados.
  - Chamar o `aiService.analyzeDocument` (que prioriza DeepSeek) com o texto extraído.
- Atualiza o prompt enviado à DeepSeek (server/deepseek.ts) para solicitar uma resposta JSON mais detalhada, incluindo resumo, pontos-chave, problemas (com severidade e localização), recomendações e elementos ausentes.
- Ajusta o mapeamento da resposta da DeepSeek em `server/ai-service.ts` para a estrutura de `findings` utilizada internamente.
- Adiciona logs detalhados em vários pontos do processo para facilitar a depuração.

A rota `/api/ai/analyze-document` permanece com sua lógica mockada por enquanto, e pode ser revisada ou removida em um commit futuro se não for mais necessária.